### PR TITLE
Added play integrity check to added safety net check for appcheck act…

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/cloud_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/cloud_firestore.dart
@@ -4,8 +4,6 @@
 
 library cloud_firestore;
 
-import 'dart:typed_data';
-
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_firestore.dart
@@ -4,7 +4,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:cloud_firestore_platform_interface/src/method_channel/method_channel_load_bundle_task.dart';

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_load_bundle_task.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_load_bundle_task.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: require_trailing_commas
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/utils/firestore_message_codec.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/utils/firestore_message_codec.dart
@@ -3,10 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:typed_data';
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:cloud_firestore_platform_interface/src/internal/field_path_type.dart';
 import 'package:cloud_firestore_platform_interface/src/method_channel/method_channel_field_value.dart';

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_firestore.dart
@@ -4,7 +4,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';

--- a/packages/cloud_functions/cloud_functions/lib/cloud_functions.dart
+++ b/packages/cloud_functions/cloud_functions/lib/cloud_functions.dart
@@ -6,7 +6,6 @@
 library cloud_functions;
 
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:cloud_functions_platform_interface/cloud_functions_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';

--- a/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppCheckPlugin.java
+++ b/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppCheckPlugin.java
@@ -14,6 +14,7 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.appcheck.AppCheckTokenResult;
 import com.google.firebase.appcheck.FirebaseAppCheck;
+import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderFactory;
 import com.google.firebase.appcheck.safetynet.SafetyNetAppCheckProviderFactory;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
@@ -80,6 +81,8 @@ public class FlutterFirebaseAppCheckPlugin
             FirebaseAppCheck firebaseAppCheck = getAppCheck(arguments);
             firebaseAppCheck.installAppCheckProviderFactory(
                 SafetyNetAppCheckProviderFactory.getInstance());
+            firebaseAppCheck.installAppCheckProviderFactory(
+                PlayIntegrityAppCheckProviderFactory.getInstance());
             taskCompletionSource.setResult(null);
           } catch (Exception e) {
             taskCompletionSource.setException(e);

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/example/lib/main.dart
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/example/lib/main.dart
@@ -71,7 +71,7 @@ class ProgrammaticTriggersExample extends StatelessWidget {
                   ),
                 );
               },
-              style: ElevatedButton.styleFrom(primary: Colors.blue),
+              style: ElevatedButton.styleFrom(backgroundColor: Colors.blue),
               child: Text(
                 'Programmatic Triggers'.toUpperCase(),
                 style: const TextStyle(color: Colors.white),
@@ -120,7 +120,7 @@ class AnalyticsEventExample extends StatelessWidget {
                   ),
                 );
               },
-              style: ElevatedButton.styleFrom(primary: Colors.blue),
+              style: ElevatedButton.styleFrom(backgroundColor: Colors.blue),
               child: Text(
                 'Log event'.toUpperCase(),
                 style: const TextStyle(color: Colors.white),

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -184,7 +184,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   if ([[GULAppDelegateSwizzler sharedApplication].delegate
           respondsToSelector:messaging_didReceiveRegistrationTokenSelector]) {
     void (*usersDidReceiveRegistrationTokenIMP)(id, SEL, FIRMessaging *, NSString *) =
-        (typeof(usersDidReceiveRegistrationTokenIMP)) & objc_msgSend;
+        (typeof(usersDidReceiveRegistrationTokenIMP))&objc_msgSend;
     usersDidReceiveRegistrationTokenIMP([GULAppDelegateSwizzler sharedApplication].delegate,
                                         messaging_didReceiveRegistrationTokenSelector, messaging,
                                         fcmToken);

--- a/packages/firebase_storage/firebase_storage/lib/firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage/lib/firebase_storage.dart
@@ -8,7 +8,6 @@ library firebase_storage;
 import 'dart:async';
 import 'dart:convert' show utf8, base64;
 import 'dart:io' show File;
-import 'dart:typed_data' show Uint8List;
 
 // import 'package:flutter/foundation.dart';
 import 'package:firebase_core/firebase_core.dart';

--- a/packages/firebase_storage/firebase_storage/test/mock.dart
+++ b/packages/firebase_storage/firebase_storage/test/mock.dart
@@ -5,7 +5,6 @@
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';

--- a/tests/test_driver/cloud_functions/cloud_functions_e2e.dart
+++ b/tests/test_driver/cloud_functions/cloud_functions_e2e.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:typed_data';
-
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:drive/drive.dart';

--- a/tests/test_driver/firebase_storage/reference_e2e.dart
+++ b/tests/test_driver/firebase_storage/reference_e2e.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:drive/drive.dart';
 import 'package:firebase_storage/firebase_storage.dart';


### PR DESCRIPTION
## Description

This PR adds the play integrity check to the already present SafetyNet app check when activating firebase app_check. Previously, only the SafetyNetAppCheck was being initialized. This PR was created to fix https://github.com/firebase/flutterfire/issues/9178. We need the play integrity check to make sure the installation of our app is legit.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

closes https://github.com/firebase/flutterfire/issues/9178 

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ x] I read and followed the [Flutter Style Guide].
- [x ] I signed the [CLA].
- [x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
